### PR TITLE
Keep abcd parallel results in memory

### DIFF
--- a/example/hargreaves_abcd_mrtm_futu.ini
+++ b/example/hargreaves_abcd_mrtm_futu.ini
@@ -95,9 +95,6 @@ runoff_module               = abcd
 # source directory name for the ABCD runoff module
 model_dir                   = abcd
 
-# output directory for the generate ABCD data arrays per basin
-output_dir                  = abcd_outputs
-
 # calibration parameters file with path for ABCDM per basin
 calib_file                  = calibrated_vic_params_per_basin_dist.npy
 

--- a/example/hargreaves_abcd_mrtm_hist.ini
+++ b/example/hargreaves_abcd_mrtm_hist.ini
@@ -95,9 +95,6 @@ runoff_module               = abcd
 # source directory name for the ABCD runoff module
 model_dir                   = abcd
 
-# output directory for the generate ABCD data arrays per basin
-output_dir                  = abcd_outputs
-
 # calibration parameters file with path for ABCDM per basin
 calib_file                  = calibrated_vic_params_per_basin_dist.npy
 

--- a/xanthos/components.py
+++ b/xanthos/components.py
@@ -240,8 +240,8 @@ class Components:
             # run all basins at once in parallel
             rg = runoff_mod.abcd_execute(n_basins=235, basin_ids=self.ref.basin_ids,
                                          pet=self.pet_out, precip=self.precip, tmin=np.nan_to_num(self.temp),
-                                         calib_file=self.s.calib_file, out_dir=self.s.ro_out_dir,
-                                         n_months=self.s.nmonths, spinup_factor=self.s.SpinUp, jobs=self.s.ro_jobs)
+                                         calib_file=self.s.calib_file, n_months=self.s.nmonths,
+                                         spinup_factor=self.s.SpinUp, jobs=self.s.ro_jobs)
 
             self.PET, self.AET, self.Q, self.Sav = rg
 

--- a/xanthos/data_reader/ini_reader.py
+++ b/xanthos/data_reader/ini_reader.py
@@ -168,7 +168,6 @@ class ConfigReader:
 
                 ro_mod = ro['abcd']
                 self.ro_model_dir = os.path.join(self.RunoffDir, ro_mod['model_dir'])
-                self.ro_out_dir = self.create_dir(os.path.join(self.OutputFolder, ro_mod['output_dir']))
                 self.calib_file = os.path.join(self.ro_model_dir, ro_mod['calib_file'])
                 self.SpinUp = int(ro_mod['SpinUp'])
                 self.ro_jobs = int(ro_mod['jobs'])

--- a/xanthos/runoff/abcd.py
+++ b/xanthos/runoff/abcd.py
@@ -407,6 +407,7 @@ def _run_basin(basin_num, pars_abcdm, basin_ids, pet, precip, tmin, n_months, sp
     :param spinup_factor    How many times to tile the historic months by
     :param method:          Either 'dist' for distributed, or 'lump' for lumped processing
     :param verbose:         True if all ABCD parameters are to be exported, False if only coords and rsim (Default)
+    :return                 A NumPy array
     """
 
     # import ABCD parameters for the target basin
@@ -433,11 +434,12 @@ def _run_basin(basin_num, pars_abcdm, basin_ids, pet, precip, tmin, n_months, sp
 
 def abcd_parallel(num_basins, pars, basin_ids, pet, precip, tmin, n_months, spinup_factor=1, jobs=-1):
     """
-    This model is made to run a basin at a time.  Running them in parallel greatly speeds things up.
-    Outputs of each function are saved to an output directory.  The user can choose to output just
-    the coordinates and simulated runoff, or the whole suite of outputs from the ABCD model.
+    This model is made to run a basin at a time.  Running them in parallel
+    greatly speeds things up. The user can choose to output just the coordinates
+    and simulated runoff, or the whole suite of outputs from the ABCD model.
 
     :param num_basins:          How many basin to run
+    :return:                    A list of NumPy arrays
     """
     rslts = Parallel(n_jobs=jobs)(delayed(_run_basin)(i, pars, basin_ids, pet, precip, tmin, n_months, spinup_factor) for i in range(1, num_basins + 1, 1))
     return(rslts)


### PR DESCRIPTION
Removes intermediate abcd output files and config options relating to the abcd_output directory.