### PR TITLE
Add max version requirement for matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1756a971afb684277e4168595743de214fc7ba8ab307af891c1efea6656af219
-size 101
+oid sha256:d4d9aa3dd1a942bf7ecca8bf302ce39ccc0bc218eb032a17f79b3814b8576c75
+size 107


### PR DESCRIPTION
Because xanthos requires python 2.7, the version of matplotlib needs to be [less than 3.0](https://github.com/matplotlib/matplotlib/issues/9404).

We can specify the maximum version in the requirements.txt file.