### PR TITLE
Allow configuration with in-memory parameters

### DIFF
--- a/xanthos/accessible/accessible.py
+++ b/xanthos/accessible/accessible.py
@@ -76,7 +76,7 @@ def AccessibleWater(settings, ref, runoff):
         edf = settings.Env_FlowPercent * np.mean(Map_runoff[:, :(hey + 1)], axis=1)
 
     # calculate available water for each basin and year
-    ac = accessible_water(q_gcam, bflow, edf, rdf.values))
+    ac = accessible_water(q_gcam, bflow, edf, rdf.values)
 
     # create accessible water output dataframe at GCAM year time step
 #    filename = os.path.join(settings.OutputFolder, 'Accessible_Water_{}'.format(settings.OutputNameStr))

--- a/xanthos/accessible/accessible.py
+++ b/xanthos/accessible/accessible.py
@@ -76,7 +76,7 @@ def AccessibleWater(settings, ref, runoff):
         edf = settings.Env_FlowPercent * np.mean(Map_runoff[:, :(hey + 1)], axis=1)
 
     # calculate available water for each basin and year
-    ac = accessible_water(q_gcam, bflow, edf, rdf.as_matrix())
+    ac = accessible_water(q_gcam, bflow, edf, rdf.values))
 
     # create accessible water output dataframe at GCAM year time step
 #    filename = os.path.join(settings.OutputFolder, 'Accessible_Water_{}'.format(settings.OutputNameStr))

--- a/xanthos/components.py
+++ b/xanthos/components.py
@@ -145,6 +145,8 @@ class Components:
     def prep_arrays(self, nm=None):
         """
         Prepare arrays.
+
+        @:param nm:     time-step number
         """
         if nm is None:
             self.P = np.copy(self.data.precip)  # keep nan in P
@@ -173,8 +175,8 @@ class Components:
             self.mth_solar_dec = np.copy(self.solar_dec[nm])
             self.mth_dr = np.copy(self.dr[nm])
             self.mth_days = np.copy(self.yr_imth_dys[nm, 2])
-            self.mth_temp_pet = np.nan_to_num(self.data.temp[:, nm])
-            self.mth_dtr_pet = np.nan_to_num(self.data.dtr[:, nm])
+            self.mth_temp_pet = np.nan_to_num(self.T)
+            self.mth_dtr_pet = np.nan_to_num(self.D)
 
         elif self.s.pet_module == 'hs':
             pass
@@ -182,7 +184,7 @@ class Components:
         elif self.s.pet_module == 'pm':
             pass
 
-    def calculate_pet(self, nm=None):
+    def calculate_pet(self):
         """
         Calculate monthly potential evapo-transpiration.
         """
@@ -436,6 +438,7 @@ class Components:
                     print("---{} in progress... ".format(notify))
                     t0 = time.time()
 
+                    ## TODO: why are these different cases?
                     # calculate PET
                     if pet:
                         print("\tProcessing PET...")

--- a/xanthos/data_reader/data_load.py
+++ b/xanthos/data_reader/data_load.py
@@ -282,7 +282,7 @@ class LoadData:
 
         @:return:               array
         """
-        # load data to array from file
+        # load data to array from file, unless data is already an array
         if isinstance(f, np.ndarray):
             arr = f
         else:

--- a/xanthos/data_reader/data_load.py
+++ b/xanthos/data_reader/data_load.py
@@ -285,6 +285,7 @@ class LoadData:
         # load data to array from file, unless data is already an array
         if isinstance(f, np.ndarray):
             arr = f
+            f = 'in memory'
         else:
             arr = self.load_data(f, 0, varname)
 

--- a/xanthos/data_reader/data_load.py
+++ b/xanthos/data_reader/data_load.py
@@ -267,6 +267,12 @@ class LoadData:
             temp = f.read().split('\n')
             return np.array([i.split(',') for i in temp])[:, 0]
 
+    def load_from_mem(self, arr, text):
+        """
+        Read an in-memory array
+        """
+        return self.validate(arr, text)
+
     def load_to_array(self, f, varname=None, neg_to_zero=False):
         """
         Loads and validates monthly input data.
@@ -311,6 +317,8 @@ class LoadData:
         if not arr.shape[1] == self.s.nmonths:
             raise ValidationException(err.format(text, self.s.nmonths, arr.shape[1]))
 
+        # TODO: Can this be removed? self.s.nmonths is divisible by 12 by default,
+        #       so the above check would also check this as well, right?
         if not arr.shape[1] % 12 == 0:
             raise ValidationException("Error: Number of months in data can not be converted into integral years.")
 
@@ -510,7 +518,6 @@ def load_gcm_var(fn, varname):
     """
     Loads climate data from the specified GCM
     """
-
     if not os.path.isfile(fn):
         raise IOError("File does not exist:  {}".format(fn))
 
@@ -548,7 +555,6 @@ def load_const_griddata(fn, headerNum=0, key=" "):
     """
     Load constant grid data stored in files defined in GRID_CONSTANTS.
     """
-
     # for MATLAB files
     if fn.endswith('.mat'):
         data = load_gcm_var(fn, key)

--- a/xanthos/data_reader/ini_reader.py
+++ b/xanthos/data_reader/ini_reader.py
@@ -625,3 +625,7 @@ class ConfigReader:
             print('Diagnostics will be performed using the data file: {}'.format(self.VICDataFile))
         except AttributeError:
             pass
+
+    def update(self, args):
+        for k, v in args.items():
+            setattr(self, k, v)

--- a/xanthos/data_reader/ini_reader.py
+++ b/xanthos/data_reader/ini_reader.py
@@ -160,7 +160,7 @@ class ConfigReader:
                 try:
                     self.TemperatureFile = os.path.join(self.pet_dir, pet_mod['TemperatureFile'])
                 except KeyError:
-                    raise('File path not provided for the TemperatureFile variable in the PET section of the config file.')
+                    raise 'File path not provided for the TemperatureFile variable in the PET section of the config file.'
 
                 try:
                     self.TempVarName = pet_mod['TempVarName']
@@ -170,7 +170,7 @@ class ConfigReader:
                 try:
                     self.DailyTemperatureRangeFile = os.path.join(self.pet_dir, pet_mod['DailyTemperatureRangeFile'])
                 except KeyError:
-                    raise('File path not provided for the DailyTemperatureRangeFile variable in the PET section of the config file.')
+                    raise 'File path not provided for the DailyTemperatureRangeFile variable in the PET section of the config file.'
 
                 try:
                     self.DTRVarName = pet_mod['DTRVarName']
@@ -231,7 +231,7 @@ class ConfigReader:
                 try:
                     self.pet_file = pt['pet_file']
                 except KeyError:
-                    raise("USAGE: Must provide a pet_file variable in the PET config section that contains the full path to an input PET file if not using an existing module.")
+                    raise "USAGE: Must provide a pet_file variable in the PET config section that contains the full path to an input PET file if not using an existing module."
 
             else:
                 msg = "ERROR: PET module '{0}' not found. Please check spelling and try again.".format(self.pet_module)
@@ -242,7 +242,7 @@ class ConfigReader:
             try:
                 self.pet_file = pt['pet_file']
             except KeyError:
-                raise("USAGE: Must provide a pet_file variable in the PET config section that contains the full path to an input PET file if not using an existing module.")
+                raise "USAGE: Must provide a pet_file variable in the PET config section that contains the full path to an input PET file if not using an existing module."
 
         # -------------------------------------------------------------------
         # -------------------------------------------------------------------
@@ -284,7 +284,7 @@ class ConfigReader:
                 try:
                     self.PrecipitationFile = os.path.join(self.ro_model_dir, ro_mod['PrecipitationFile'])
                 except KeyError:
-                    raise('File path not provided for the PrecipitationFile variable in the GCAM runoff section of the config file.')
+                    raise 'File path not provided for the PrecipitationFile variable in the GCAM runoff section of the config file.'
 
                 try:
                     self.PrecipVarName = ro_mod['PrecipVarName']
@@ -294,7 +294,7 @@ class ConfigReader:
                 try:
                     self.TemperatureFile = os.path.join(self.ro_model_dir, ro_mod['TemperatureFile'])
                 except KeyError:
-                    raise('File path not provided for the TemperatureFile variable in the GCAM runoff section of the config file.')
+                    raise 'File path not provided for the TemperatureFile variable in the GCAM runoff section of the config file.'
 
                 try:
                     self.TempVarName = ro_mod['TempVarName']
@@ -304,7 +304,7 @@ class ConfigReader:
                 try:
                     self.DailyTemperatureRangeFile = os.path.join(self.ro_model_dir, ro_mod['DailyTemperatureRangeFile'])
                 except KeyError:
-                    raise('File path not provided for the DailyTemperatureRangeFile variable in the GCAM runoff section of the config file.')
+                    raise 'File path not provided for the DailyTemperatureRangeFile variable in the GCAM runoff section of the config file.'
 
                 try:
                     self.DTRVarName = ro_mod['DTRVarName']
@@ -322,7 +322,7 @@ class ConfigReader:
                 try:
                     self.PrecipitationFile = ro_mod['PrecipitationFile']
                 except KeyError:
-                    raise('File path not provided for the PrecipitationFile variable in the ABCD runoff section of the config file.')
+                    raise 'File path not provided for the PrecipitationFile variable in the ABCD runoff section of the config file.'
 
 
                 try:
@@ -333,7 +333,7 @@ class ConfigReader:
                 try:
                     self.TempMinFile = ro_mod['TempMinFile']
                 except KeyError:
-                    raise('File path not provided for the TempMinFile variable in the ABCD runoff section of the config file.')
+                    raise 'File path not provided for the TempMinFile variable in the ABCD runoff section of the config file.'
 
                 try:
                     self.TempMinVarName = ro_mod['TempMinVarName']
@@ -354,7 +354,7 @@ class ConfigReader:
             #     try:
             #         self.PrecipitationFile = ro_mod['PrecipitationFile']
             #     except KeyError:
-            #         raise('File path not provided for the PrecipitationFile variable in the ABCD runoff section of the config file.')
+            #         raise 'File path not provided for the PrecipitationFile variable in the ABCD runoff section of the config file.'
             #
             #
             #     try:
@@ -365,7 +365,7 @@ class ConfigReader:
             #     try:
             #         self.TempMinFile = ro_mod['TempMinFile']
             #     except KeyError:
-            #         raise('File path not provided for the TempMinFile variable in the ABCD runoff section of the config file.')
+            #         raise 'File path not provided for the TempMinFile variable in the ABCD runoff section of the config file.'
             #
             #     try:
             #         self.TempMinVarName = ro_mod['TempMinVarName']

--- a/xanthos/data_reader/ini_reader.py
+++ b/xanthos/data_reader/ini_reader.py
@@ -627,5 +627,10 @@ class ConfigReader:
             pass
 
     def update(self, args):
+        """
+        Overwrite configuration options
+
+        :@param args:   Dictionary of parameters, where the key is the parameter name
+        """
         for k, v in args.items():
             setattr(self, k, v)

--- a/xanthos/model.py
+++ b/xanthos/model.py
@@ -51,6 +51,8 @@ class Xanthos:
     def execute(self, args={}):
         """
         Instantiate and write log file.
+
+        @:param args:   Dictionary of config parameters 
         """
         # stage data
         self.stage(args)

--- a/xanthos/model.py
+++ b/xanthos/model.py
@@ -33,11 +33,13 @@ class Xanthos:
         if not os.path.exists(pth):
             os.makedirs(pth)
 
-    def stage(self):
+    def stage(self, mem_args):
         """
         Set up run.
         """
         self.config = ConfigReader(self.ini)
+
+        self.config.update(mem_args)
 
         # create output directory
         self.make_dir(self.config.OutputFolder)
@@ -46,12 +48,12 @@ class Xanthos:
         sys.stdout = Logger()
         self.log_file = os.path.join(self.config.OutputFolder, 'logfile.log')
 
-    def execute(self):
+    def execute(self, args={}):
         """
         Instantiate and write log file.
         """
         # stage data
-        self.stage()
+        self.stage(args)
 
         with open(self.log_file, 'w') as sys.stdout.log:
             self.config.log_info()

--- a/xanthos/pet/penman_monteith.py
+++ b/xanthos/pet/penman_monteith.py
@@ -393,23 +393,12 @@ def run_pmpet(data, ncells, nlcs, start_yr, end_yr, water_idx, snow_idx, land_co
     """
     Run Penman-Monteith PET.
 
-    :param in_dir:              Full path location to the input files
     :param ncells:              Integer number of grid cells in the data
     :param nlcs:                Number of land classes in the input data
     :param start_yr:            Start year of the project in YYYY format
     :param end_yr:              End year of the project in YYYY format
-    :param f_tair:              Full path with file name and extension to surface air temperature in degrees Celsius,
-                                2D [ncells, nmonths]
-    :param f_tmin:              Full path with file name and extension to minimum surface air temperature in degrees
-                                Celsus, 2D [ncells, nmonths]
-    :param f_rhs:               Full path with file name and extension to relative humidity (rhs) in percent
-    :param f_wind:              Full path with file name and extension to wind speed in meters/second
-    :param f_rsds:              Full path with file name and extension to surface downwelling shortwave radiation (rsds)
-                                in W m-2
-    :param f_rlds:              Full path with file name and extension to surface longwave radiation (rlds) in W m-2
     :param water_idx:           index of water in the land cover data
     :param snow_idx:            index of snow in the land cover data
-    :param land_cover_file      Full path with file name and extension to the land cover data [n_cells, n_land_classes, n_yrs]
     :param land_cover_years     list of integer years in YYYY format that are contained in the land cover data
 
     :return:                    PET array [ncells, nmonths]


### PR DESCRIPTION
Adds flexibility so that Xanthos can be run loading inputs from memory rather than on disk. This helps make Xanthos more accessible to other tools or input pre-processing.

To call within python:
```
import xanthos
import numpy as np

# Input temperature data for Xanthos as a numpy array. Expects a dictionary where
# the key is the Xanthos config parameter it is replacing.
tempdata = {'pm_tas': np.empty([67420, 372])}

# Instantiate Xanthos
config_path = 'xanthos/example/pm_abcd_mrtm.ini'
xth = xanthos.Xanthos(config_path)

# Run Xanthos, passing in the parameter list
xth.execute(tempdata) 
```

Another example, this time calling Xanthos from R:

```
library(reticulate)

# Input temperature data for Xanthos as an R matrix. Must be a named list where
# the name is the Xanthos config parameter it is replacing.
fakedata <- list(pm_tas = matrix(rep(1:67420, 372), nrow = 67420, ncol = 372))

# Instantiate Xanthos
config_path <- 'xanthos/example/pm_abcd_mrtm.ini'
xth.mod <- import('xanthos')
xth <- xth.mod$Xanthos(config_path)

# Run Xanthos, passing in the parameter list
xth$execute(fakedata)
```