### PR TITLE
Thornthwaite

### DIFF
--- a/xanthos/components.py
+++ b/xanthos/components.py
@@ -64,12 +64,14 @@ class Components:
             self.pet_out = None
             sft = helper.calc_sinusoidal_factor(self.yr_imth_dys)
             self.solar_dec = sft[0]
-            self.dr = sft[1]
 
         elif self.s.pet_module == 'hs':
             pass
 
         elif self.s.pet_module == 'pm':
+            pass
+
+        elif self.s.pet_module == 'thornthwaite':
             pass
 
         # runoff
@@ -131,6 +133,9 @@ class Components:
         elif self.s.pet_module == 'pm':
             import pet.penman_monteith as pet_mod
 
+        elif self.s.pet_module == 'thornthwaite':
+            import pet.thornthwaite as pet_mod
+
         # import desired module for Runoff
         if self.s.runoff_module == 'gwam':
             import runoff.gwam as runoff_mod
@@ -182,6 +187,9 @@ class Components:
         elif self.s.pet_module == 'pm':
             pass
 
+        elif self.s.pet_module == 'thornthwaite':
+            pass
+
     def calculate_pet(self, nm=None):
         """
         Calculate monthly potential evapo-transpiration.
@@ -198,6 +206,11 @@ class Components:
 
             return pet_mod.run_pmpet(self.data, self.s.ncell, self.s.pm_nlcs, self.s.StartYear, self.s.EndYear,
                                      self.s.pm_water_idx, self.s.pm_snow_idx, self.s.pm_lc_years)
+
+        elif self.s.pet_module == 'thornthwaite':
+
+            return pet_mod.execute(self.data.tair, self.s.ncell, self.data.lat_radians,
+                                   self.s.StartYear, self.s.EndYear)
 
         elif self.s.pet_module == 'none':
             return self.data.pet_out

--- a/xanthos/components.py
+++ b/xanthos/components.py
@@ -64,6 +64,7 @@ class Components:
             self.pet_out = None
             sft = helper.calc_sinusoidal_factor(self.yr_imth_dys)
             self.solar_dec = sft[0]
+            self.dr = sft[1]
 
         elif self.s.pet_module == 'hs':
             pass

--- a/xanthos/components.py
+++ b/xanthos/components.py
@@ -209,7 +209,7 @@ class Components:
 
         elif self.s.pet_module == 'thornthwaite':
 
-            return pet_mod.execute(self.data.tair, self.s.ncell, self.data.lat_radians,
+            return pet_mod.execute(self.data.tair, self.data.lat_radians,
                                    self.s.StartYear, self.s.EndYear)
 
         elif self.s.pet_module == 'none':

--- a/xanthos/configurations.py
+++ b/xanthos/configurations.py
@@ -130,6 +130,59 @@ def hargreaves_abcd_mrtm(config):
     return c
 
 
+def thornthwaite_abcd_mrtm(config):
+    """
+    Model configuration for the following:
+
+    PET:                Thornthwaite
+    RUNOFF:             ABCD
+    ROUTING:            Modified River Transport Model (MRTM)
+
+
+    Spin-up is built in to the ABCD model and does not need to be calculated separately.
+
+    :param config:      Configuration object generated from user-defined config.ini file
+    :return:            Object containing all return values.
+    """
+
+    # instantiate hydro class
+    c = Components(config)
+
+    # run model
+    c.simulation(pet=True,
+                 pet_num_steps=config.nmonths,
+                 pet_step=None,
+                 runoff=True,
+                 runoff_step=None,
+                 routing=True,
+                 routing_num_steps=config.nmonths,
+                 routing_step='month',
+                 notify='Simulation')
+
+    # accessible water module
+    c.accessible_water()
+
+    # hydropower potential
+    c.hydropower_potential()
+
+    # hydropower actual
+    c.hydropower_actual()
+
+    # diagnostics
+    c.diagnostics()
+
+    # output simulation data
+    c.output_simulation()
+
+    # aggregate outputs
+    c.aggregate_outputs()
+
+    # create time series plots
+    c.plots()
+
+    return c
+
+
 def none_none_mrtm(config):
     """
     Model configuration for the following:

--- a/xanthos/data_reader/data_load.py
+++ b/xanthos/data_reader/data_load.py
@@ -110,6 +110,9 @@ class LoadData:
             # static data
             self.elev = np.nan_to_num(np.load(self.s.pm_elev))
 
+        elif self.s.pet_module == 'thornthwaite':
+            self.tair = np.nan_to_num(np.load(self.s.trn_tas))
+
         elif self.s.pet_module == 'none':
 
             # load user supplied PET data

--- a/xanthos/data_reader/ini_reader.py
+++ b/xanthos/data_reader/ini_reader.py
@@ -220,7 +220,6 @@ class ConfigReader:
                 # climate data
                 self.trn_tas = os.path.join(self.pet_dir, pet_mod['trn_tas'])
 
-
             # -*****************************************************************-
             # CONDITIONAL FOR NEW PET MODULE
             #

--- a/xanthos/data_reader/ini_reader.py
+++ b/xanthos/data_reader/ini_reader.py
@@ -213,6 +213,14 @@ class ConfigReader:
                 self.pm_laimax = os.path.join(self.pet_dir, 'gcam_laimax.csv')
                 self.pm_elev = os.path.join(self.pet_dir, 'elev.npy')
 
+            elif self.pet_module == 'thornthwaite':
+                pet_mod = pt['thornthwaite']
+                self.pet_dir = os.path.join(self.PET, pet_mod['pet_dir'])
+
+                # climate data
+                self.trn_tas = os.path.join(self.pet_dir, pet_mod['trn_tas'])
+
+
             # -*****************************************************************-
             # CONDITIONAL FOR NEW PET MODULE
             #

--- a/xanthos/data_reader/ini_reader.py
+++ b/xanthos/data_reader/ini_reader.py
@@ -160,7 +160,8 @@ class ConfigReader:
                 try:
                     self.TemperatureFile = os.path.join(self.pet_dir, pet_mod['TemperatureFile'])
                 except KeyError:
-                    raise 'File path not provided for the TemperatureFile variable in the PET section of the config file.'
+                    print('File path not provided for the TemperatureFile variable in the PET section of the config file.')
+                    raise
 
                 try:
                     self.TempVarName = pet_mod['TempVarName']
@@ -170,7 +171,8 @@ class ConfigReader:
                 try:
                     self.DailyTemperatureRangeFile = os.path.join(self.pet_dir, pet_mod['DailyTemperatureRangeFile'])
                 except KeyError:
-                    raise 'File path not provided for the DailyTemperatureRangeFile variable in the PET section of the config file.'
+                    print('File path not provided for the DailyTemperatureRangeFile variable in the PET section of the config file.')
+                    raise
 
                 try:
                     self.DTRVarName = pet_mod['DTRVarName']
@@ -291,7 +293,8 @@ class ConfigReader:
                 try:
                     self.PrecipitationFile = os.path.join(self.ro_model_dir, ro_mod['PrecipitationFile'])
                 except KeyError:
-                    raise 'File path not provided for the PrecipitationFile variable in the GCAM runoff section of the config file.'
+                    print('File path not provided for the PrecipitationFile variable in the GCAM runoff section of the config file.')
+                    raise
 
                 try:
                     self.PrecipVarName = ro_mod['PrecipVarName']
@@ -301,7 +304,8 @@ class ConfigReader:
                 try:
                     self.TemperatureFile = os.path.join(self.ro_model_dir, ro_mod['TemperatureFile'])
                 except KeyError:
-                    raise 'File path not provided for the TemperatureFile variable in the GCAM runoff section of the config file.'
+                    print('File path not provided for the TemperatureFile variable in the GCAM runoff section of the config file.')
+                    raise
 
                 try:
                     self.TempVarName = ro_mod['TempVarName']
@@ -311,7 +315,8 @@ class ConfigReader:
                 try:
                     self.DailyTemperatureRangeFile = os.path.join(self.ro_model_dir, ro_mod['DailyTemperatureRangeFile'])
                 except KeyError:
-                    raise 'File path not provided for the DailyTemperatureRangeFile variable in the GCAM runoff section of the config file.'
+                    print('File path not provided for the DailyTemperatureRangeFile variable in the GCAM runoff section of the config file.')
+                    raise
 
                 try:
                     self.DTRVarName = ro_mod['DTRVarName']
@@ -329,7 +334,8 @@ class ConfigReader:
                 try:
                     self.PrecipitationFile = ro_mod['PrecipitationFile']
                 except KeyError:
-                    raise 'File path not provided for the PrecipitationFile variable in the ABCD runoff section of the config file.'
+                    print('File path not provided for the PrecipitationFile variable in the ABCD runoff section of the config file.')
+                    raise
 
 
                 try:
@@ -340,7 +346,8 @@ class ConfigReader:
                 try:
                     self.TempMinFile = ro_mod['TempMinFile']
                 except KeyError:
-                    raise 'File path not provided for the TempMinFile variable in the ABCD runoff section of the config file.'
+                    print('File path not provided for the TempMinFile variable in the ABCD runoff section of the config file.')
+                    raise
 
                 try:
                     self.TempMinVarName = ro_mod['TempMinVarName']
@@ -361,7 +368,8 @@ class ConfigReader:
             #     try:
             #         self.PrecipitationFile = ro_mod['PrecipitationFile']
             #     except KeyError:
-            #         raise 'File path not provided for the PrecipitationFile variable in the ABCD runoff section of the config file.'
+            #         print('File path not provided for the PrecipitationFile variable in the ABCD runoff section of the config file.')
+            #         raise
             #
             #
             #     try:
@@ -372,7 +380,8 @@ class ConfigReader:
             #     try:
             #         self.TempMinFile = ro_mod['TempMinFile']
             #     except KeyError:
-            #         raise 'File path not provided for the TempMinFile variable in the ABCD runoff section of the config file.'
+            #         print('File path not provided for the TempMinFile variable in the ABCD runoff section of the config file.')
+            #         raise
             #
             #     try:
             #         self.TempMinVarName = ro_mod['TempMinVarName']

--- a/xanthos/model.py
+++ b/xanthos/model.py
@@ -72,6 +72,9 @@ class Xanthos:
             elif self.config.mod_cfg == 'hs_abcd_mrtm':
                 mods.hs_abcd_mrtm(self.config)
 
+            elif self.config.mod_cfg == 'thornthwaite_abcd_mrtm':
+                mods.thornthwaite_abcd_mrtm(self.config)
+
             elif self.config.mod_cfg == 'none_gwam_mrtm':
                 mods.none_gwam_mrtm(self.config)
 

--- a/xanthos/pet/penman_monteith.py
+++ b/xanthos/pet/penman_monteith.py
@@ -393,23 +393,20 @@ def run_pmpet(data, ncells, nlcs, start_yr, end_yr, water_idx, snow_idx, land_co
     """
     Run Penman-Monteith PET.
 
-    :param in_dir:              Full path location to the input files
+    :param data:                Object containing temperature, humidity, wind, radiation, and land cover data:
+                                    - surface air temperature in degrees Celsius, 2D [ncells, nmonths]
+                                    - minimum surface air temperature in degrees Celsus, 2D [ncells, nmonths]
+                                    - relative humidity (rhs) in percent
+                                    - wind speed in meters/second
+                                    - surface downwelling shortwave radiation (rsds) in W m-2
+                                    - surface longwave radiation (rlds) in W m-2
+                                    - land cover data [n_cells, n_land_classes, n_yrs]
     :param ncells:              Integer number of grid cells in the data
     :param nlcs:                Number of land classes in the input data
     :param start_yr:            Start year of the project in YYYY format
     :param end_yr:              End year of the project in YYYY format
-    :param f_tair:              Full path with file name and extension to surface air temperature in degrees Celsius,
-                                2D [ncells, nmonths]
-    :param f_tmin:              Full path with file name and extension to minimum surface air temperature in degrees
-                                Celsus, 2D [ncells, nmonths]
-    :param f_rhs:               Full path with file name and extension to relative humidity (rhs) in percent
-    :param f_wind:              Full path with file name and extension to wind speed in meters/second
-    :param f_rsds:              Full path with file name and extension to surface downwelling shortwave radiation (rsds)
-                                in W m-2
-    :param f_rlds:              Full path with file name and extension to surface longwave radiation (rlds) in W m-2
     :param water_idx:           index of water in the land cover data
     :param snow_idx:            index of snow in the land cover data
-    :param land_cover_file      Full path with file name and extension to the land cover data [n_cells, n_land_classes, n_yrs]
     :param land_cover_years     list of integer years in YYYY format that are contained in the land cover data
 
     :return:                    PET array [ncells, nmonths]

--- a/xanthos/pet/thornthwaite.py
+++ b/xanthos/pet/thornthwaite.py
@@ -1,0 +1,130 @@
+"""
+Calculating Monthly PET (Thornthwaite Method)
+
+Rewritten:
+@date: 8/7/18
+@author: Caleb Braun (caleb.braun@pnnl.gov)
+@Project: Xanthos V2.0
+
+License:  BSD 2-Clause, see LICENSE and DISCLAIMER files
+
+Copyright (c) 2018, Battelle Memorial Institute
+"""
+import calendar
+import numpy as np
+
+
+def calc_daylight_hours(mth_days, lat_radians):
+    """
+    Calculate average day length (hours) for each month at each latitude.
+
+    @:param mth_days:       Iterable containing number of days for each month
+    @:param lat_radians:    Numpy array of latitudes in radians
+    @:return:               Numpy array (lat_radians x months)
+    """
+    EARTH_OBLIQ = 0.409  # Earth's obliquitiy in radians
+    HOURS_IN_DY = 24.0
+    NDAYS_IN_YR = np.arange(sum(mth_days)) + 1
+
+    # Solar declination
+    solar_dec = EARTH_OBLIQ * np.sin(((2 * np.pi / 365.0) * NDAYS_IN_YR - 1.39))
+
+    # Sunset hour angle (domain of arccos is -1 <= x <= 1 radians; in this case,
+    # greater or smaller values represent 24 hours sunlight/darkness)
+    sunset_hour_angle_cos = -np.tan(lat_radians[:, np.newaxis]) * np.tan(solar_dec[np.newaxis, :])
+    sunset_hour_angle = np.arccos(np.clip(sunset_hour_angle_cos, -1, 1))
+
+    # Sum daylight hours for each month, then divde by month length for mean
+    daylight_hours = sunset_hour_angle * (HOURS_IN_DY / np.pi)
+    month_indices = np.cumsum(mth_days) - mth_days[0]
+    mthly_daylight_hours = np.add.reduceat(daylight_hours, month_indices, axis=1) / mth_days
+
+    return mthly_daylight_hours
+
+
+def execute(tas, lat_radians, start_yr, end_yr):
+    """
+    Estimate potential evapotranspiration (PET) using the Thornthwaite method.
+
+    Thornthwaite equation:
+
+        PET = 1.6 (L/12) (N/30) (10Ta / I)^a
+
+    where, for each month:
+
+    L  = the mean day length in hours of the month being calculated
+    N  = the number of days in the month being calculated
+    Ta = the mean daily air temperature in deg C (if negative use 0) of the
+         month being calculated
+    I  = a heat index which depends on the 12 monthly mean temperatures and
+         is calculated as the sum of (Ta_i / 5)^1.514 for each month i, where
+         Ta_i is the air temperature for each month in the year
+    a  = (6.75 x 10-7) * I^3 - (7.71 x 10-5) * I^2 + (1.792 x 10-2) * I + 0.49239
+
+    For more information, see Thornthwaite (1948), available here:
+        https://unc.live/2QdZGNw
+
+    :param tas:             Numpy array of mean daily air temperature in deg C
+    :param lat_radians:     Vector of latitude in radians for each cell in tas
+    :param start_yr:        Data start year
+    :param end_yr:          Data end year
+
+    :return:    Estimated monthly potential evaporation of each month of the
+                year in mm/month
+    """
+    MONTHDAYS = (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+    LEAP_MONTHDAYS = (31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+    NMONTHS = 12
+
+    # All nans and negatives are treated as zero
+    tas[np.logical_or(np.isnan(tas), tas < 0)] = 0
+
+    ## Heat Index and exponential calculations:
+    i = np.copy(tas)
+
+    # Monthly Thornthwaite Heat Index formula:
+    i = np.power((i / 5), 1.514)
+
+    # Aggregate to Annual Heat Index
+    I = np.add.reduceat(i, np.arange(0, i.shape[1], NMONTHS), axis=1)
+
+    # Calculate the exponential constants
+    a = (.000000675 * I ** 3) - (.0000771 * I ** 2 ) + (.0179 * I) + .492
+
+    # Spread yearly values back over all months
+    I = np.repeat(I, NMONTHS, axis=1)
+    a = np.repeat(a, NMONTHS, axis=1)
+
+
+    ## Pet calculations:
+    # Calculate PET before adjusting for real month length and theoretical
+    # sunshine hours.
+    # If you don't pass `out` the indices where (I == 0) will be uninitialized.
+    pet_unadj = np.divide(10 * tas, I, out=np.zeros_like(I), where=(I != 0))
+    pet_unadj = 16 * np.power(pet_unadj, a)
+
+
+    ## Correction variables
+    # Monthly mean daylight hours
+    L = calc_daylight_hours(MONTHDAYS, lat_radians)
+    L = np.repeat(L, (end_yr - start_yr + 1), axis=1)
+
+    # Determine which years in the data are leap years
+    leapyears = [calendar.isleap(y) for y in range(start_yr, end_yr + 1)]
+
+    # Replace any leap years with leap year mean daylight hours
+    if any(leapyears):
+        L_leap = calc_daylight_hours(LEAP_MONTHDAYS, lat_radians)
+        leap_months = np.repeat(leapyears, NMONTHS)
+        L[:, leap_months] = np.tile(L_leap, sum(leapyears))
+
+    # 1d array of the number of days in each month
+    N = np.array([LEAP_MONTHDAYS if ly else MONTHDAYS for ly in leapyears]).flatten()
+
+    # Final equation
+    #   L = Monthly mean daylight hours  (shape = pet_unadj.shape)
+    #   N = Number of days in each month (shape = nmonths)
+    pet = pet_unadj * (L / NMONTHS) * (N / 30)
+
+    # return numpy array of PET in mm/month [ncells x nmonths]
+    return pet


### PR DESCRIPTION
Adds a new PET module that uses the Thornthwaite Method. This module is generally more simple, and does not rely on daily temperature data and several other inputs.

Comparing against the Penman-Montieth method (using the same inputs provided in `example/input`), this method produces values for PET 1 to 2 times greater, on average:

![image](https://user-images.githubusercontent.com/12344924/45242397-d52f2580-b2bd-11e8-83aa-5c2d4f6a1f75.png)

Using this module, the diagnostics report global total runoff as 42,640 km^3/yr, whereas the Penman-Montieth module gives 45,624 km^3/yr.

Example configuration for running this module is attached.

[trn_abcd_mrtm.txt](https://github.com/JGCRI/xanthos/files/2362513/trn_abcd_mrtm.txt)