### PR TITLE
Upgrade Xanthos to Python 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4d9aa3dd1a942bf7ecca8bf302ce39ccc0bc218eb032a17f79b3814b8576c75
-size 107
+oid sha256:b66023b5c1fdd597ff69e907e1c01a880ddc2072608caf682e5690c8c5325e3e
+size 109

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ License:  BSD 2-Clause, see LICENSE and DISCLAIMER files
 
 Copyright (c) 2017, Battelle Memorial Institute
 """
-import sys
 
 
 class VersionError(Exception):
@@ -15,15 +14,11 @@ class VersionError(Exception):
         Exception.__init__(self, *args, **kwargs)
 
 
-py_version = '{0}.{1}'.format(sys.version_info.major, sys.version_info.minor)
-if py_version != '2.7':
-    raise VersionError("Xanthos must be ran using Python 2.7.  You are using Python {0}.".format(py_version))
-
-
 try:
     from setuptools import setup, find_packages
 except ImportError:
-    raise("Must have setuptools installed to run setup.py. Please install and try again.")
+    print("Must have setuptools installed to run setup.py. Please install and try again.")
+    raise
 
 
 def readme():
@@ -38,7 +33,7 @@ def get_requirements():
 
 setup(
     name='xanthos',
-    version='2.0.0',
+    version='2.1.0',
     packages=find_packages(),
     url='https://github.com/jgcri/xanthos',
     license='BSD 2-Clause',
@@ -46,5 +41,6 @@ setup(
     author_email='chris.vernon@pnnl.gov; xinya.li@pnl.gov',
     description='A global hydrologic model for GCAM',
     long_description=readme(),
-    install_requires=get_requirements()
+    install_requires=get_requirements(),
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4',
 )

--- a/xanthos/accessible/accessible.py
+++ b/xanthos/accessible/accessible.py
@@ -68,7 +68,7 @@ def AccessibleWater(settings, ref, runoff):
         edf = settings.Env_FlowPercent * np.mean(Map_runoff, axis=1)
 
     else:
-        ValidYears = range(settings.StartYear, settings.EndYear + 1)
+        ValidYears = list(range(settings.StartYear, settings.EndYear + 1))
         hey = ValidYears.index(settings.HistEndYear)
         edf = settings.Env_FlowPercent * np.mean(Map_runoff[:, :(hey + 1)], axis=1)
 
@@ -111,8 +111,8 @@ def RollingWindowFilter(data, window, Dimension=0):
 
 def QInGCAMYears(qs, settings):
     """Create data frame with only target GCAM years."""
-    ValidYears = range(settings.StartYear, settings.EndYear + 1)
-    GCAMYears = range(settings.GCAM_StartYear, settings.GCAM_EndYear + 1, settings.GCAM_YearStep)
+    ValidYears = list(range(settings.StartYear, settings.EndYear + 1))
+    GCAMYears = list(range(settings.GCAM_StartYear, settings.GCAM_EndYear + 1, settings.GCAM_YearStep))
     q_gcam = np.zeros((qs.shape[0], len(GCAMYears)), dtype=float)
 
     for i in range(len(GCAMYears)):
@@ -135,7 +135,7 @@ def accessible_water(qtot, base, efr, res):
 
 def genGCAMOutput(filename, data, bdf, settings):
     """Create data frame containing basin_id, basin_name, and accessible water by year."""
-    years = map(str, range(settings.GCAM_StartYear, settings.GCAM_EndYear + 1, settings.GCAM_YearStep))
+    years = list(map(str, list(range(settings.GCAM_StartYear, settings.GCAM_EndYear + 1, settings.GCAM_YearStep))))
     hdr = "id,name," + ",".join([year for year in years])
 
     maxID = len(bdf)

--- a/xanthos/data_reader/data_load.py
+++ b/xanthos/data_reader/data_load.py
@@ -1,5 +1,6 @@
 """
-Module to load input data files
+Module to load input data files.
+
 Created 8/8/2016
 
 Modified:
@@ -21,14 +22,22 @@ from xanthos.utils.numpy_parser import GetArrayCSV, GetArrayTXT
 
 
 class ValidationException(Exception):
+    """Exception for invalid configuration options."""
+
     def __init__(self, *args, **kwargs):
+        """Exception for invalid configuration options."""
         Exception.__init__(self, *args, **kwargs)
 
 
 class LoadData:
+    """Load system-wide input data."""
 
     def __init__(self, config_obj):
+        """
+        Validate the configuration set up.
 
+        :param config_obj:      A ConfigObj object that has data from a config file.
+        """
         self.s = config_obj
 
         # get data for PET module selected
@@ -38,7 +47,8 @@ class LoadData:
             self.temp = self.load_to_array(self.s.TemperatureFile, varname=self.s.TempVarName)
 
             # monthly average of daily temperature range in degree c
-            self.dtr = self.load_to_array(self.s.DailyTemperatureRangeFile, varname=self.s.DTRVarName, neg_to_zero=True)
+            self.dtr = self.load_to_array(self.s.DailyTemperatureRangeFile, varname=self.s.DTRVarName,
+                                          neg_to_zero=True)
 
         elif self.s.pet_module == 'hs':
 
@@ -205,9 +215,7 @@ class LoadData:
             self.cal_obs = self.load_data(self.s.cal_observed, 0)[:, [0, 3]]
 
     def load_soil_data(self):
-        """
-        Load soil moisture file into array if in future mode, else stage zeros array.
-        """
+        """Load soil moisture file into array if in future mode, else stage zeros array."""
         try:
             # Initialize channel storage/soil moisture.
             if self.s.HistFlag.lower() == "true":
@@ -223,6 +231,8 @@ class LoadData:
 
     def load_soil_moisture(self, missing=-9999):
         """
+        Load soil moisture data.
+
         Assign max soil moisture (mm/month) [2] to Sm.  For historic data use 0.5 * sm to an initial value to pass to
         runoff model. If future mode, read values from historical file.
         """
@@ -254,17 +264,13 @@ class LoadData:
         return data
 
     def get_country_names(self):
-        """
-        Get an array of country names corresponding to GCAM countries
-        """
+        """Get an array of country names corresponding to GCAM countries."""
         with open(self.s.CountryNames, 'r') as f:
             country = f.read().splitlines()
             return np.array([i.split(',') for i in country])[:, 1]
 
     def get_region_names(self):
-        """
-        Get an array of region names corresponding to the GCAM region id map
-        """
+        """Get an array of region names corresponding to the GCAM region id map."""
         with open(self.s.GCAMRegionNames, 'r') as f:
             f.readline()
             region = f.read().split('\n')
@@ -272,7 +278,7 @@ class LoadData:
 
     def load_to_array(self, f, varname=None, neg_to_zero=False, nan_to_num=False):
         """
-        Loads and validates monthly input data.
+        Load and validate monthly input data.
 
         Dimension: 67420 x number of years*12, for example:
         Historical: 1950-2005  672 months
@@ -329,9 +335,7 @@ class LoadData:
 
     @staticmethod
     def load_data(fn, headerNum=0, key=" "):
-        """
-        Load grid data stored in files defined in GRID_CONSTANTS.
-        """
+        """Load grid data stored in files defined in GRID_CONSTANTS."""
         # for MATLAB files
         if fn.endswith('.mat'):
             data = sio.loadmat(fn)[key]
@@ -382,13 +386,14 @@ class LoadData:
 
 
 class LoadReferenceData:
-    """
-    Load reference data.
+    """Load reference data."""
 
-    :param settings:        settings object from configuration
-    """
     def __init__(self, settings):
+        """
+        Load the base reference data.
 
+        :param settings:        settings object from configuration
+        """
         # Area value for each land grid cell: 67420 x 1, convert from ha to km2
         self.area = load_const_griddata(settings.Area) * 0.01
 
@@ -433,7 +438,7 @@ class LoadReferenceData:
 
 def load_climate_data(fle, n_cells, n_months, varname=None, neg_to_zero=False):
     """
-    Loads and checks input climate data.
+    Load and check input climate data.
 
     Dimension: 67420 x number of years*12, for example:
     Historical: 1950-2005  672 months
@@ -483,9 +488,7 @@ def load_routing_data(fle, ngridrow, ngridcol, map_index, skip=68, rep_val=None)
 
 
 def load_soil_data(settings):
-    """
-    Load soil moisture file into array if in future mode, else stage zeros array.
-    """
+    """Load soil moisture file into array if in future mode, else stage zeros array."""
     try:
         # Initialize channel storage/soil moisture.
         if settings.HistFlag == "True":
@@ -501,9 +504,7 @@ def load_soil_data(settings):
 
 
 def load_chs_data(settings):
-    """
-    Load channel velocity file into array if in future mode, else stage zeros array.
-    """
+    """Load channel velocity file into array if in future mode, else stage zeros array."""
     try:
 
         # Initialize channel storage/soil moisture.
@@ -518,9 +519,7 @@ def load_chs_data(settings):
 
 
 def load_gcm_var(fn, varname):
-    """
-    Loads climate data from the specified GCM
-    """
+    """Load climate data from the specified GCM."""
     if not os.path.isfile(fn):
         raise IOError("File does not exist:  {}".format(fn))
 
@@ -539,8 +538,10 @@ def check_climate_data(data, n_cells, n_months, text):
     :param n_months:        number of months
     :param text:            name of target variable
     """
-    err_cell = "Error: Inconsistent {0} data grid size. Expecting size: {1}. Received size: {2}".format(text, n_cells, data.shape[0])
-    err_mth = "Error: Inconsistent {0} data grid size. Expecting size: {1}. Received size: {2}".format(text, n_months, data.shape[1])
+    err_cell = "Error: Inconsistent {0} data grid size. Expecting size: {1}. Received size: {2}".format(
+        text, n_cells, data.shape[0])
+    err_mth = "Error: Inconsistent {0} data grid size. Expecting size: {1}. Received size: {2}".format(
+        text, n_months, data.shape[1])
 
     if not data.shape[0] == n_cells:
         raise ValidationException(err_cell)
@@ -555,9 +556,7 @@ def check_climate_data(data, n_cells, n_months, text):
 
 
 def load_const_griddata(fn, headerNum=0, key=" "):
-    """
-    Load constant grid data stored in files defined in GRID_CONSTANTS.
-    """
+    """Load constant grid data stored in files defined in GRID_CONSTANTS."""
     # for MATLAB files
     if fn.endswith('.mat'):
         data = load_gcm_var(fn, key)
@@ -595,7 +594,8 @@ def load_const_griddata(fn, headerNum=0, key=" "):
 
         datagrp = sio.netcdf.netcdf_file(fn, 'r', mmap=False)
 
-        # copy() added to handle numpy 'ValueError:assignment destination is read-only' related to non-contiguous memory
+        # copy() added to handle numpy 'ValueError:assignment destination is read-only'
+        # related to non-contiguous memory
         try:
             data = datagrp.variables[key][:, :].copy()
 
@@ -608,9 +608,7 @@ def load_const_griddata(fn, headerNum=0, key=" "):
 
 
 def vectorize(data, ngridrow, ngridcol, map_index, skip):
-    """
-    Convert 2D Map (360 x 720) Matrix to 1D Map(67420)
-    """
+    """Convert 2D Map (360 x 720) Matrix to 1D Map(67420)."""
     new = np.zeros((ngridrow, ngridcol), dtype=float) - 9999
 
     for i in range(0, data.shape[0]):
@@ -622,6 +620,7 @@ def vectorize(data, ngridrow, ngridcol, map_index, skip):
 
 
 def load_soil_moisture(d, ngrids, missing=-9999):
+    """Load soil moisture."""
     data = np.zeros((ngrids, 5), order='F')
 
     data[:, 0] = d.area

--- a/xanthos/data_reader/ini_reader.py
+++ b/xanthos/data_reader/ini_reader.py
@@ -161,7 +161,8 @@ class ConfigReader:
                 try:
                     self.TemperatureFile = os.path.join(self.pet_dir, pet_mod['TemperatureFile'])
                 except KeyError:
-                    logging.exception('File path not provided for the TemperatureFile variable in the PET section of the config file.')
+                    logging.exception("File path not provided for the TemperatureFile "
+                                      "variable in the PET section of the config file.")
                     raise
 
                 try:
@@ -172,7 +173,8 @@ class ConfigReader:
                 try:
                     self.DailyTemperatureRangeFile = os.path.join(self.pet_dir, pet_mod['DailyTemperatureRangeFile'])
                 except KeyError:
-                    logging.exception('File path not provided for the DailyTemperatureRangeFile variable in the PET section of the config file.')
+                    logging.exception("File path not provided for the DailyTemperatureRangeFile "
+                                      "variable in the PET section of the config file.")
                     raise
 
                 try:
@@ -241,18 +243,24 @@ class ConfigReader:
                 try:
                     self.pet_file = pt['pet_file']
                 except KeyError:
-                    raise "USAGE: Must provide a pet_file variable in the PET config section that contains the full path to an input PET file if not using an existing module."
+                    raise ValidationException(
+                        "USAGE: Must provide a pet_file variable in the PET config section that "
+                        "contains the full path to an input PET file if not using an existing module."
+                    )
 
             else:
-                msg = "ERROR: PET module '{0}' not found. Please check spelling and try again.".format(self.pet_module)
-                raise ValidationException(msg)
+                raise ValidationException("ERROR: PET module '{0}' not found. Please check "
+                                          "spelling and try again.".format(self.pet_module))
         else:
             self.pet_module = 'none'
 
             try:
                 self.pet_file = pt['pet_file']
             except KeyError:
-                raise "USAGE: Must provide a pet_file variable in the PET config section that contains the full path to an input PET file if not using an existing module."
+                raise ValidationException(
+                    "USAGE: Must provide a pet_file variable in the PET config section that "
+                    "contains the full path to an input PET file if not using an existing module."
+                )
 
         # -------------------------------------------------------------------
         # -------------------------------------------------------------------
@@ -289,12 +297,14 @@ class ConfigReader:
                         self.SavVarName = ro_mod['SavVarName']
 
                     except KeyError:
-                        raise ValidationException("Error: ChStorageFile and ChStorageVarName are not defined for Future Mode.")
+                        raise ValidationException("Error: ChStorageFile and ChStorageVarName "
+                                                  "are not defined for Future Mode.")
 
                 try:
                     self.PrecipitationFile = os.path.join(self.ro_model_dir, ro_mod['PrecipitationFile'])
                 except KeyError:
-                    logging.exception('File path not provided for the PrecipitationFile variable in the GCAM runoff section of the config file.')
+                    logging.exception("File path not provided for the PrecipitationFile variable "
+                                      "in the GCAM runoff section of the config file.")
                     raise
 
                 try:
@@ -305,7 +315,8 @@ class ConfigReader:
                 try:
                     self.TemperatureFile = os.path.join(self.ro_model_dir, ro_mod['TemperatureFile'])
                 except KeyError:
-                    logging.exception('File path not provided for the TemperatureFile variable in the GCAM runoff section of the config file.')
+                    logging.exception("File path not provided for the TemperatureFile "
+                                      "variable in the GCAM runoff section of the config file.")
                     raise
 
                 try:
@@ -314,9 +325,11 @@ class ConfigReader:
                     self.TempVarName = None
 
                 try:
-                    self.DailyTemperatureRangeFile = os.path.join(self.ro_model_dir, ro_mod['DailyTemperatureRangeFile'])
+                    self.DailyTemperatureRangeFile = os.path.join(
+                        self.ro_model_dir, ro_mod['DailyTemperatureRangeFile'])
                 except KeyError:
-                    logging.exception('File path not provided for the DailyTemperatureRangeFile variable in the GCAM runoff section of the config file.')
+                    logging.exception("File path not provided for the DailyTemperatureRangeFile "
+                                      "variable in the GCAM runoff section of the config file.")
                     raise
 
                 try:
@@ -335,9 +348,9 @@ class ConfigReader:
                 try:
                     self.PrecipitationFile = ro_mod['PrecipitationFile']
                 except KeyError:
-                    logging.exception('File path not provided for the PrecipitationFile variable in the ABCD runoff section of the config file.')
+                    logging.exception("File path not provided for the PrecipitationFile "
+                                      "variable in the ABCD runoff section of the config file.")
                     raise
-
 
                 try:
                     self.PrecipVarName = ro_mod['PrecipVarName']
@@ -347,7 +360,8 @@ class ConfigReader:
                 try:
                     self.TempMinFile = ro_mod['TempMinFile']
                 except KeyError:
-                    logging.exception('File path not provided for the TempMinFile variable in the ABCD runoff section of the config file.')
+                    logging.exception("File path not provided for the TempMinFile "
+                                      "variable in the ABCD runoff section of the config file.")
                     raise
 
                 try:
@@ -369,7 +383,8 @@ class ConfigReader:
             #     try:
             #         self.PrecipitationFile = ro_mod['PrecipitationFile']
             #     except KeyError:
-            #         logging.exception('File path not provided for the PrecipitationFile variable in the ABCD runoff section of the config file.')
+            #         logging.exception('File path not provided for the PrecipitationFile variable '
+            #                           'in the ABCD runoff section of the config file.')
             #         raise
             #
             #
@@ -381,7 +396,8 @@ class ConfigReader:
             #     try:
             #         self.TempMinFile = ro_mod['TempMinFile']
             #     except KeyError:
-            #         logging.exception('File path not provided for the TempMinFile variable in the ABCD runoff section of the config file.')
+            #         logging.exception('File path not provided for the TempMinFile variable '
+            #                           'in the ABCD runoff section of the config file.')
             #         raise
             #
             #     try:
@@ -394,7 +410,8 @@ class ConfigReader:
                 pass
 
             else:
-                raise ValidationException("ERROR: Runoff module '{0}' not found. Please check spelling and try again.".format(self.runoff_module))
+                raise ValidationException("ERROR: Runoff module '{0}' not found. Please check "
+                                          "spelling and try again.".format(self.runoff_module))
         else:
             self.runoff_module = 'none'
 
@@ -452,7 +469,8 @@ class ConfigReader:
                 pass
 
             else:
-                raise ValidationException("ERROR: Routing module '{0}' not found. Please check spelling and try again.".format(self.routing_module))
+                raise ValidationException("ERROR: Routing module '{0}' not found. Please check "
+                                          "spelling and try again.".format(self.routing_module))
 
         else:
             self.routing_module = 'none'
@@ -502,13 +520,13 @@ class ConfigReader:
                 self.TimeSeriesMapID = 999
 
                 try:
-                    l = int(t['MapID'])
-                    self.TimeSeriesMapID = l
+                    map_id = int(t['MapID'])
+                    self.TimeSeriesMapID = map_id
 
-                except:
+                except TypeError:
                     # as list
-                    l = list(map(int, t['MapID']))
-                    self.TimeSeriesMapID = l
+                    map_id = list(map(int, t['MapID']))
+                    self.TimeSeriesMapID = map_id
 
         # accessible water
         if a:
@@ -523,7 +541,8 @@ class ConfigReader:
                 self.Env_FlowPercent = float(a['Env_FlowPercent'])
 
                 if (self.StartYear > self.GCAM_StartYear) or (self.EndYear < self.GCAM_EndYear):
-                    raise ValidationException("Accessible water range of GCAM years are outside the range of years in climate data.")
+                    raise ValidationException("Accessible water range of GCAM years are outside "
+                                              "the range of years in climate data.")
 
         # hydropower potential
         if hp:
@@ -575,7 +594,8 @@ class ConfigReader:
         if set_calib == 0:
 
             if unit not in valid_runoff:
-                raise ValidationException("Calibration data input units '{}' for runoff data not in required units '{}'".format(unit, valid_runoff))
+                raise ValidationException("Calibration data input units '{}' for runoff data "
+                                          "not in required units '{}'".format(unit, valid_runoff))
 
             else:
                 return unit
@@ -583,7 +603,8 @@ class ConfigReader:
         elif set_calib == 1:
 
             if unit not in valid_streamflow:
-                raise ValidationException("Calibration data input units '{}' for streamflow data not in required units '{}'".format(unit, valid_streamflow))
+                raise ValidationException("Calibration data input units '{}' for streamflow data "
+                                          "not in required units '{}'".format(unit, valid_streamflow))
 
             else:
                 return unit
@@ -593,7 +614,8 @@ class ConfigReader:
         Check to see if the target year is within the bounds of the data.
         """
         if (yr < self.StartYear) or (yr > self.EndYear):
-            raise ValidationException("Accessible water year {0} is outside the range of years in the climate data.".format(yr))
+            raise ValidationException("Accessible water year {0} is outside the range "
+                                      "of years in the climate data.".format(yr))
         else:
             return yr
 

--- a/xanthos/data_reader/ini_reader.py
+++ b/xanthos/data_reader/ini_reader.py
@@ -507,7 +507,7 @@ class ConfigReader:
 
                 except:
                     # as list
-                    l = map(int, t['MapID'])
+                    l = list(map(int, t['MapID']))
                     self.TimeSeriesMapID = l
 
         # accessible water
@@ -651,5 +651,5 @@ class ConfigReader:
 
         :@param args:   Dictionary of parameters, where the key is the parameter name
         """
-        for k, v in args.items():
+        for k, v in list(args.items()):
             setattr(self, k, v)

--- a/xanthos/data_writer/out_writer.py
+++ b/xanthos/data_writer/out_writer.py
@@ -184,7 +184,7 @@ def SaveNetCDF(filename, data, Settings, varstr):
 
 
 def writecsvMap(filename, data, Settings):
-    years = map(str, range(Settings.StartYear, Settings.EndYear + 1))
+    years = list(map(str, list(range(Settings.StartYear, Settings.EndYear + 1))))
     headerline = "id," + ",".join([year for year in years])
 
     with open(filename + '.csv', 'w') as outfile:

--- a/xanthos/diagnostics/diagnostics.py
+++ b/xanthos/diagnostics/diagnostics.py
@@ -44,7 +44,7 @@ def Diagnostics(settings, Q, ref):
 
     VIC = ref.vic
 
-    VICyears = range(1971, 2001)
+    VICyears = list(range(1971, 2001))
     try:
         si = VICyears.index(settings.StartYear)
     except:

--- a/xanthos/pet/hargreaves_samani.py
+++ b/xanthos/pet/hargreaves_samani.py
@@ -18,7 +18,7 @@ import numpy as np
 def days_per_month(start_year, end_year):
     """Get days per month as list. Account for leap years."""
     l = []
-    yrs = range(start_year, end_year + 1, 1)
+    yrs = list(range(start_year, end_year + 1, 1))
 
     for yr in yrs:
 

--- a/xanthos/pet/penman_monteith.py
+++ b/xanthos/pet/penman_monteith.py
@@ -303,7 +303,7 @@ def et_veg(v, nlcs, nmonths, ncells):
     rhrc = np.where(rhrc > rtot, rtot, rhrc)
 
     apres = dz * 86400 * (v.sx * ac + rho * v.cp * (v.esx - vap) * fc / rhrc) * fwet / (
-            (v.sx + p * 0.01 * v.cp * rvc / (v.lambda1 * 0.622 * rhrc)) * v.lambda1)
+        (v.sx + p * 0.01 * v.cp * rvc / (v.lambda1 * 0.622 * rhrc)) * v.lambda1)
 
     ewet_c = np.zeros_like(lai)
     ewet_c = np.where(rh >= 70, apres, ewet_c)
@@ -311,9 +311,9 @@ def et_veg(v, nlcs, nmonths, ncells):
     rasoil = rtot * rr / (rtot + rr)
 
     ewet_soil = 86400 * dz * (v.sx * asoil + rho * v.cp * (1 - fc) * (v.esx - vap) / rasoil) * fwet / (
-            (v.sx + v.gamma * rtot / rasoil) * v.lambda1)
+        (v.sx + v.gamma * rtot / rasoil) * v.lambda1)
     esoilpot = 86400 * dz * (v.sx * asoil + rho * v.cp * (1 - fc) * (v.esx - vap) / rasoil) * (1 - fwet) / (
-            (v.sx + v.gamma * rtot / rasoil) * v.lambda1)
+        (v.sx + v.gamma * rtot / rasoil) * v.lambda1)
 
     beta = np.tile(v.c.beta, (ncells, nmonths, 1))
     beta = np.swapaxes(beta, 0, -1)
@@ -323,7 +323,7 @@ def et_veg(v, nlcs, nmonths, ncells):
 
     # ET from the plants (mm mon-1)
     trans = dz * 86400 * (v.sx * ac + rho * v.cp * (v.esx - vap) * fc / ra) * (1 - fwet) / (
-            (v.sx + v.gamma * (1 + rs / ra)) * v.lambda1)
+        (v.sx + v.gamma * (1 + rs / ra)) * v.lambda1)
     trans = np.where(fc == 0, 0, trans)
 
     eet = trans + ewet_c + esoil
@@ -353,7 +353,7 @@ def et_water(v, nmonths, emiss):
 
     ewetx = rn2x * v.dz * 0.6 / 2845
     ewety = v.dz * 86400 * (v.sx * ax + v.gamma * 6.43 * (0.5 + 0.54 * v.wind2x) * (v.esx - v.vapx)) / (
-                (v.sx + v.gamma) * v.lambda1)
+        (v.sx + v.gamma) * v.lambda1)
     ewet = np.where(v.tairx < -1, ewetx, ewety)
     ewet[ewet < 0.0] = 0.0
 

--- a/xanthos/pet/thornthwaite.py
+++ b/xanthos/pet/thornthwaite.py
@@ -124,7 +124,7 @@ def execute(tas, lat_radians, start_yr, end_yr):
     # Final equation
     #   L = Monthly mean daylight hours  (shape = pet_unadj.shape)
     #   N = Number of days in each month (shape = nmonths)
-    pet = pet_unadj * (L / NMONTHS) * (N / 30)
+    pet = pet_unadj * (L / NMONTHS) * (N / 30.0)
 
     # return numpy array of PET in mm/month [ncells x nmonths]
     return pet

--- a/xanthos/routing/mrtm.py
+++ b/xanthos/routing/mrtm.py
@@ -1,4 +1,4 @@
-'''
+"""
 @date   10/14/2016
 @author: lixi729
 @email: xinya.li@pnl.gov
@@ -7,14 +7,14 @@
 License:  BSD 2-Clause, see LICENSE and DISCLAIMER files
 
 Copyright (c) 2017, Battelle Memorial Institute
-'''
+"""
 
 import numpy as np
 import scipy.sparse as sparse
 
 
 def streamrouting(L, S0, F0, ChV, q, area, nday, dt, UM):
-    '''
+    """
     L:    flow distance (m)                                        = (N x 1)
     S0:   initial channel storage value for the month (m^3)        = (N x 1)
     F0:   initial channel flow value (instantaneous) for the month (m^3/s) = (N x 1)
@@ -29,7 +29,7 @@ def streamrouting(L, S0, F0, ChV, q, area, nday, dt, UM):
     S:     channel storage, unit m3
     Favg:  monthly average channel flow, unit m3/s
     F:     instantaneous channel flow, unit m3/s
-    '''
+    """
 
     N = L.shape[0]  # number of cells
 

--- a/xanthos/routing/mrtm.py
+++ b/xanthos/routing/mrtm.py
@@ -33,7 +33,7 @@ def streamrouting(L, S0, F0, ChV, q, area, nday, dt, UM):
 
     N = L.shape[0]  # number of cells
 
-    nt = nday * 24 * 3600 / dt  # number of time steps
+    nt = int(nday * 24 * 3600 / dt)  # number of time steps
 
     # setup
     S = np.copy(S0)

--- a/xanthos/runoff/abcd.py
+++ b/xanthos/runoff/abcd.py
@@ -339,7 +339,7 @@ def abcd_parallel(num_basins, pars, basin_ids, pet, precip, tmin, n_months, spin
     :param num_basins:          How many basin to run
     :return:                    A list of NumPy arrays
     """
-    rslts = Parallel(n_jobs=jobs)(delayed(_run_basin)(i, pars, basin_ids, pet, precip, tmin, n_months, spinup_steps) for i in range(1, num_basins + 1, 1))
+    rslts = Parallel(n_jobs=jobs)(delayed(_run_basin)(i, pars, basin_ids, pet, precip, tmin, n_months, spinup_steps) for i in list(range(1, num_basins + 1, 1)))
     return(rslts)
 
 


### PR DESCRIPTION
Allow Xanthos to run with either python 2 or python 3.

- Fixes a bug in the Thornthwaite module when running python 2 where integer division was used where a float output was needed.