### PR TITLE
Ensure drought statistics are written into their output array.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 matrix:
   include:
-    - python: 2.7
     - python: 3.6
       dist: xenial
 cache: pip

--- a/xanthos/drought/drought_stats.py
+++ b/xanthos/drought/drought_stats.py
@@ -141,9 +141,9 @@ class DroughtStats:
             it = I[t, :]
 
             isdrought = hydro < thresh
-            dt = np.where(isdrought, dtm1+1, 0.0)
-            st = np.where(isdrought, stm1 + (thresh - hydro) / thresh, 0.0)
-            it = np.where(isdrought, st / dt, 0.0)
+            dt[:] = np.where(isdrought, dtm1+1, 0.0)
+            st[:] = np.where(isdrought, stm1 + (thresh - hydro) / thresh, 0.0)
+            it[:] = np.where(isdrought, st / dt, 0.0)
 
         return (S, I, D)
 


### PR DESCRIPTION
The problem here was that we were setting a variable equal to an array slice, and then assigning it with the results of the time step's drought calculation.  However, in order for that to work as intended, we have to do it in a way that doesn't rebind the reference.  This fix should do the trick, based on some simple tests:
```
>>> z = np.zeros((5,5))
>>> z
array([[ 0.,  0.,  0.,  0.,  0.],
       [ 0.,  0.,  0.,  0.,  0.],
       [ 0.,  0.,  0.,  0.,  0.],
       [ 0.,  0.,  0.,  0.,  0.],
       [ 0.,  0.,  0.,  0.,  0.]])
>>> z1 = z[1,:]
>>> z1
array([ 0.,  0.,  0.,  0.,  0.])
>>> z1 = np.array([1,2,3,4,5])
>>> z
array([[ 0.,  0.,  0.,  0.,  0.],
       [ 0.,  0.,  0.,  0.,  0.],
       [ 0.,  0.,  0.,  0.,  0.],
       [ 0.,  0.,  0.,  0.,  0.],
       [ 0.,  0.,  0.,  0.,  0.]])
>>> z1 = z[1,:]
>>> z1[:] = np.array([1,2,3,4,5])
>>> z
array([[ 0.,  0.,  0.,  0.,  0.],
       [ 1.,  2.,  3.,  4.,  5.],
       [ 0.,  0.,  0.,  0.,  0.],
       [ 0.,  0.,  0.,  0.,  0.],
       [ 0.,  0.,  0.,  0.,  0.]])
```

That said, I haven't been able to test this, since I don't have Xanthos set up to run anywhere.  If one of you guys could do a short run to verify that this does the trick, I'd be much obliged.
