### PR TITLE
Fix unit issues with average channel flow

### DIFF
--- a/xanthos/routing/mrtm.py
+++ b/xanthos/routing/mrtm.py
@@ -42,7 +42,7 @@ def streamrouting(L, S0, F0, ChV, q, area, nday, dt, UM):
     tauinv = ChV / L
     dtinv = 1. / dt
 
-    erlateral = (q * area) / (1e6 * 10**9) / (nday * 24 * 3600)  # q -> erlateral: mm/month to m^3/s
+    erlateral = (q * area) * (1e6 / 1e3) / (nday * 24 * 3600)  # q -> erlateral: mm/month to m^3/s
 
     for t in range(nt):
 


### PR DESCRIPTION
### Summary
Re-calculating the conversion from mm/mth -> m3/s gives very different results than what was here before.

Yearly aggregation of average channel flow now done with `mean`.

### Results

#### Archived Xanthos Results:
```
>>> df = pd.read_csv('avgchflow_m3persec_pm_abcd_mrtm_watch_mth_1971_2001.csv')
>>> df.iloc[:, [1, 13, 25, -36, -24, -12]].describe().apply(lambda x:round(x, 5))
             197101        197201        197301        199901        200001        200101
count   67420.00000   67420.00000   67420.00000   67420.00000   67420.00000   67420.00000
mean      208.35486     202.27336     209.13997     215.75312     217.40135     233.68360
std      2340.81348    2435.31804    2429.81124    2310.00733    2270.67291    2571.72749
min         0.00000       0.00000       0.00000      -0.00000      -0.00000      -0.00000
25%         0.84514       0.84316       0.66648       0.41216       0.41551       0.35270
50%         6.18582       5.66907       5.53967       6.92213       6.89836       6.86076
75%        30.01979      29.97153      30.91424      35.77941      36.38768      38.03924
max    147228.52641  150003.56196  149183.18542  141240.73898  149411.05769  156714.00890
```

#### Current Xanthos Results:
```
>>> df = pd.read_csv('pm_abcd_mrtm_watch_1971_2001_hydro/avgchflow_m3persec_pm_abcd_mrtm_watch_1971_2001_hydro.csv')
>>> df.iloc[:, [1, 13, 25, -36, -24, -12]].describe().apply(lambda x:round(x, 5))
             197101        197201        197301        199901        200001        200101
count   67420.00000   67420.00000   67420.00000   67420.00000   67420.00000   67420.00000
mean      207.86002     201.88028     208.67325     215.35572     216.90523     233.22524
std      2339.27596    2433.84554    2428.30375    2308.48215    2268.91642    2570.07730
min         0.00000       0.00000       0.00000      -0.00000      -0.00000      -0.00000
25%         0.84362       0.84098       0.66587       0.40926       0.41488       0.35130
50%         6.17303       5.65463       5.53106       6.90901       6.88752       6.84717
75%        29.91619      29.85484      30.86446      35.70523      36.30114      37.94253
max    147183.28292  149942.94207  149133.48635  141180.13522  149341.55101  156648.45958
```