### PR TITLE
Change print to logging.warning in ini_reader.

### DIFF
--- a/xanthos/data_reader/ini_reader.py
+++ b/xanthos/data_reader/ini_reader.py
@@ -603,5 +603,5 @@ class ConfigReader:
         """
         for k, v in args.items():
             if not hasattr(self, k):
-                print('Warning: {} is not a valid parameter'.format(k))
+                logging.warning('{} is not a valid parameter'.format(k))
             setattr(self, k, v)


### PR DESCRIPTION
Fixes #49

@crvernon 
FWIW, I wasn't able to run the test suite locally because Xanthos doesn't install cleanly under python-3.7.7 on our system.  The error is:
```
error in xanthos setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Invalid requirement, parse error at "'://git-l'"
```
No time to track down the cause right now, unfortunately.
