### PR TITLE
Potential fix for #66

### DIFF
--- a/docs/available_modules.md
+++ b/docs/available_modules.md
@@ -72,7 +72,6 @@ Config tag:
 | -------- | ----------- | -------- |
 | runoff_module | The name of the runoff model to be used.  Currently supported:  abcd (for ABCD), gwam (for GWAM), and none (for cases where the user will provide their own runoff input file). | True |
 | runoff_dir | The directory name of the runoff module chosen where its input files are stored | True |
-| runoff_file | Only used if `runoff_module` is set to `none`.  This will be a full path file with extension to the input runoff data in mm/month.  Array must be 2-D, where (gridcell_idx, month_idx).  File must be saved as a NumPy array file (.npy). | False |
 
 ### ABCD
 Config tag:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas~=1.1.4
 configobj>=5.0.6
 joblib~=1.0.1
 matplotlib~=3.4.2
+requests~=2.27.1

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "configobj>=5.0.6",
         "joblib~=1.0.1",
         "matplotlib~=3.4.2",
+        "requests~=2.27.1"
     ],
     python_requires='>=3.6',
     include_package_data=True

--- a/xanthos/components.py
+++ b/xanthos/components.py
@@ -244,6 +244,7 @@ class Components:
 
             # if user is providing a custom runoff file
             if self.s.alt_runoff is not None:
+                self.PET = pet
                 self.Q = np.load(self.s.alt_runoff)
 
     def calculate_routing(self, runoff):

--- a/xanthos/configurations.py
+++ b/xanthos/configurations.py
@@ -59,7 +59,7 @@ class ConfigRunner:
         """
         # acceptable components to run
         PET_COMPONENTS = ['hs', 'hargreaves', 'pm', 'thornthwaite']
-        RUNOFF_COMPONENTS = ['abcd', 'gwam']
+        RUNOFF_COMPONENTS = ['abcd', 'gwam', 'none']
         ROUTING_COMPONENTS = ['mrtm']
 
         # runoff components that need the whole model to do spin-up

--- a/xanthos/install_supplement.py
+++ b/xanthos/install_supplement.py
@@ -3,7 +3,7 @@ import zipfile
 
 import requests
 
-from pkg_resources import get_distribution
+from pkg_resources import get_distribution, DistributionNotFound
 from io import BytesIO as BytesIO
 
 
@@ -28,7 +28,10 @@ class InstallSupplement:
         current Xanthos distribution."""
 
         # get the current version of xanthos that is installed
-        current_version = get_distribution('xanthos').version
+        try:
+            current_version = get_distribution('xanthos').version
+        except DistributionNotFound:
+            current_version = list(InstallSupplement.DATA_VERSION_URLS.keys())[-1]
 
         try:
             data_link = InstallSupplement.DATA_VERSION_URLS[current_version]


### PR DESCRIPTION
* honor `pet_file` and `alt_runoff` file when running routing only
* add `requests` to requirements
* remove `runoff_file` from docs